### PR TITLE
Rename HttpWebHookType to WebHookType

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/WebHookType.java
+++ b/src/main/java/com/microsoft/azure/functions/WebHookType.java
@@ -27,6 +27,6 @@ package com.microsoft.azure.functions;
  * use the {@code com.microsoft.azure.functions.annotation.HttpTrigger.authLevel()} property with Slack webhooks.</li>
  * </ul>
  */
-public enum HttpWebHookType {
+public enum WebHookType {
     NONE, GENERICJSON, GITHUB, SLACK;
 }

--- a/src/main/java/com/microsoft/azure/functions/annotation/HttpTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/HttpTrigger.java
@@ -12,7 +12,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import com.microsoft.azure.functions.HttpMethod;
-import com.microsoft.azure.functions.HttpWebHookType;
+import com.microsoft.azure.functions.WebHookType;
 
 /**
  * <p>The HttpTrigger annotation is applied to Azure functions that will be triggered by a call to the HTTP endpoint that
@@ -137,5 +137,5 @@ public @interface HttpTrigger {
      *
      * @return A webhook type.
      */
-    HttpWebHookType webHookType() default HttpWebHookType.NONE;
+    WebHookType webHookType() default WebHookType.NONE;
 }


### PR DESCRIPTION
Rename HttpWebHookType to WebHookType to match function.json property [binding-expressions---json-payloads](https://docs.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings#binding-expressions---json-payloads)