### PR TITLE
Remove deprecated 'summary' attribute from HTML table

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/annotation/TimerTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/TimerTrigger.java
@@ -55,9 +55,8 @@ public @interface TimerTrigger {
      * A <a href="http://en.wikipedia.org/wiki/Cron#CRON_expression">CRON expression</a> in the format
      * {@code {second} {minute} {hour} {day} {month} {day-of-week}}.
      *
-     * <p>Some examples of CRON expressions that could be used include:</p>
-     *
      * <table>
+     *     <caption>A table showing some examples of CRON expressions that could be used.</caption>
      *     <tr>
      *         <th>Goal</th>
      *         <th>CRON Expression</th>

--- a/src/main/java/com/microsoft/azure/functions/annotation/TimerTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/TimerTrigger.java
@@ -57,7 +57,7 @@ public @interface TimerTrigger {
      *
      * <p>Some examples of CRON expressions that could be used include:</p>
      *
-     * <table summary="CRON expression examples">
+     * <table>
      *     <tr>
      *         <th>Goal</th>
      *         <th>CRON Expression</th>


### PR DESCRIPTION
I created this table in the javadoc, and used the 'summary' attribute to describe the content. Under HTML5 the summary tag is deprecated and therefore should be removed. This pull request removes the summary tag and replaces it with a caption element, and this enables the project to build under JDK 11.