### PR TITLE
Adding annotation to ServiceBusQueueTrigger and ServiceBusTopicTrigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ hs_err_pid*
 /target/
 /Azure.Functions.Cli/*
 /azure-functions-java-worker/
+
+#IDE
+*.iml

--- a/src/main/java/com/microsoft/azure/functions/annotation/ServiceBusQueueTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/ServiceBusQueueTrigger.java
@@ -86,4 +86,10 @@ public @interface ServiceBusQueueTrigger {
    * @return The Service Bus queue permission.
    */
   AccessRights access() default AccessRights.MANAGE;
+
+  /**
+   * Defines the value indicating whether the sessions are enabled.
+   * @return The value indicating whether the sessions are enabled.
+   */
+  boolean isSessionsEnabled() default false;
 }

--- a/src/main/java/com/microsoft/azure/functions/annotation/ServiceBusTopicTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/ServiceBusTopicTrigger.java
@@ -95,4 +95,10 @@ public @interface ServiceBusTopicTrigger {
    * @return The Service Bus topic permission.
    */
   AccessRights access() default AccessRights.MANAGE;
+
+  /**
+   * Defines the value indicating whether the sessions are enabled.
+   * @return The value indicating whether the sessions are enabled.
+   */
+  boolean isSessionsEnabled() default false;
 }


### PR DESCRIPTION
ServiceBusQueueTrigger and ServiceBusTopicTrigger will have new annotation to support isSessionsEnabled.

The C# attributes is [IsSessionsEnabled](https://github.com/Azure/azure-functions-servicebus-extension/blob/dev/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ServiceBusTriggerAttribute.cs#L89)