### PR TITLE
Fix Ci false positive

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -43,6 +43,7 @@ StopOnFailedExecution
 # Get azure-functions-library 
 Write-Host "Build and install azure-functions-java-library" 
 cmd.exe /c '.\mvnBuild.bat'
+StopOnFailedExecution
 $libraryPom = Get-Content "pom.xml" -Raw
 $libraryPom -match "<version>(.*)</version>"
 $libraryVersion = $matches[1]


### PR DESCRIPTION
At my last PR, we found that false-positives happens on the CI even if test fails, it still success. 
This PR is fix for it. 

This PR should fail. Since I don't fix the Kafka Trigger issue on test. Once Kafka Trigger one is merged, we can test if it pass or not.

This PR successfully detect the test. The root cause was, the ps file forget to add cheking the last status on test batch script.