### PR TITLE
Add missing configuration properties for the Timer Trigger annotation

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/annotation/TimerTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/TimerTrigger.java
@@ -90,4 +90,17 @@ public @interface TimerTrigger {
      * @return A string representing a CRON expression that will be used to schedule a function to run.
      */
     String schedule();
+    
+    /*
+     * Defines the value indicating whether the function should be invoked when the runtime starts.
+     * @return The value indicating whether the function should be invoked when the runtime starts.
+     */
+    boolean runOnStartup() default false;
+    
+    
+    /*
+     * Defines the value indicating whether the schedule should be monitored.
+     * @return The value indicating whether the schedule should be monitored.
+     */
+    boolean useMonitor() default false;
 }


### PR DESCRIPTION
The Timer Trigger annotation is missing the `runOnStartup` and `useMonitor` properties that are [covered in the documentation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer?tabs=java).

Without these, I believe the only workaround today is to update the generated `function.json` directly in the JAR.