### PR TITLE
Add RetryContext as part of ExecutionContext

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/ExecutionContext.java
+++ b/src/main/java/com/microsoft/azure/functions/ExecutionContext.java
@@ -42,5 +42,13 @@ public interface ExecutionContext {
     default TraceContext getTraceContext() {
         return null;
     }
+
+    /**
+     * Returns the retry context.
+     * @return the retry context
+     */
+    default RetryContext getRetryContext(){
+        return null;
+    }
 }
 

--- a/src/main/java/com/microsoft/azure/functions/RetryContext.java
+++ b/src/main/java/com/microsoft/azure/functions/RetryContext.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.functions;
+
+/**
+ * The Retry context that is obtained from the host.
+ *
+ * @since 2.0.0
+ */
+public interface RetryContext {
+
+    /**
+     * Returns the current retry count
+     *
+     * @return the current retry count.
+     */
+    int getRetrycount();
+
+    /**
+     * Returns the max retry count
+     *
+     * @return the max retry count.
+     */
+    int getMaxretrycount();
+
+    /**
+     * Returns the exception that caused the retry
+     *
+     * @return the exception that caused the retry.
+     */
+    RpcException getException();
+
+}

--- a/src/main/java/com/microsoft/azure/functions/RpcException.java
+++ b/src/main/java/com/microsoft/azure/functions/RpcException.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+package com.microsoft.azure.functions;
+
+
+public interface RpcException {
+
+    // Source of the exception
+    String getSource();
+
+    // Stack trace for the exception
+    String getStacktrace();
+
+    // Textual message describing the exception
+    String getMessage();
+
+}


### PR DESCRIPTION
Updating the java library to have RetryContext as part of the ExecutionContext
Issue: Azure/azure-webjobs-sdk#2595 added support to access retry context within execution context.

