### PR TITLE
chore: make scm-info refer to this project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:https://github.com/Azure/azure-functions-java-worker</connection>
-		<developerConnection>scm:git:git@github.com:Azure/azure-functions-java-worker</developerConnection>
-		<url>https://github.com/Azure/azure-functions-java-worker</url>
+		<connection>scm:git:https://github.com/Azure/azure-functions-java-library</connection>
+		<developerConnection>scm:git:git@github.com:Azure/azure-functions-java-library</developerConnection>
+		<url>https://github.com/Azure/azure-functions-java-library</url>
 		<tag>HEAD</tag>
 	</scm>
 


### PR DESCRIPTION
Tools generating automatic release notes for the latest 3.0.0 refers to https://github.com/Azure/azure-functions-java-worker, which is confusing.

Is any good reasons the SCM-info is refering to `azure-functions-java-worker` instead of this project, or could that be changes as proposed in this PR?