### PR TITLE
Adding lingerms property in kafka output binding

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/annotation/KafkaOutput.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/KafkaOutput.java
@@ -190,4 +190,12 @@ public @interface KafkaOutput {
      * @return The ssl key password.
      */
     String sslKeyPassword() default "";
+
+    /**
+     * lingerMS property provides the time between batches of messages
+     * being sent to cluster. Larger value allows more batching results in high throughput.
+     *
+     * @return Linger.ms for librdkafka
+     */
+    int lingerMs() default 5;
 }


### PR DESCRIPTION
- Added the support for kafka output binding. This is required due to adding the [support ](https://github.com/Azure/azure-functions-kafka-extension/pull/407)
- This change doesn't requires any junit test