### PR TITLE
fix: exclude paths from codeql evaluation, skip e2e tests on scheduled runs and update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 #   https://help.github.com/articles/about-codeowners/  
 
 # Default owners for repo
-* @azure/azure-functions-extensions-bundle-admins
+* @azure/azure-functions-java-worker-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 #   https://help.github.com/articles/about-codeowners/  
 
 # Default owners for repo
-*	@Azure/azure-functions-java-worker-admins
+* @azure/azure-functions-extensions-bundle-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 #   https://help.github.com/articles/about-codeowners/  
 
 # Default owners for repo
-*	@manvkaur @vrdmr @gavin-aguiar @hallvictoria @ahmedmuhsin
+*	@Azure/azure-functions-java-worker-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,5 @@
 #   https://blog.github.com/2017-07-06-introducing-code-owners/
 #   https://help.github.com/articles/about-codeowners/  
 
-# Default owner for repo
-*	@pragnagopa
-*   @amamounelsayed
+# Default owners for repo
+*	@manvkaur @vrdmr @gavin-aguiar @hallvictoria @ahmedmuhsin

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -43,6 +43,9 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
+    sdl:
+      codeql:
+        enabledOnNonDefaultBranches: true
 
     stages:
     - stage: BuildAndTest

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -43,9 +43,6 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
-    sdl:
-      codeql:
-        enabledOnNonDefaultBranches: true
 
     stages:
     - stage: BuildAndTest
@@ -53,7 +50,7 @@ extends:
         sdl:
           codeql:
             runSourceLanguagesInSourceAnalysis: true
-            buildIdentifier: java_additions_official
+            buildIdentifier: java_library_official
             excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
       jobs:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -35,6 +35,12 @@ resources:
 variables:
   - template: ci/variables/build.yml@eng
   - template: ci/variables/cfs.yml@eng
+  - name: codeql.language
+    value: java,powershell
+  - name: codeql.buildIdentifier
+    value: java_library_official
+  - name: codeql.excludePathPatterns
+    value: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-worker'
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
@@ -46,14 +52,8 @@ extends:
 
     stages:
     - stage: BuildAndTest
-      templateContext:
-        sdl:
-          codeql:
-            runSourceLanguagesInSourceAnalysis: true
-            buildIdentifier: java_library_official
-            excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
       jobs:
       - template: /eng/ci/templates/official/jobs/build-and-test.yml@self
         parameters:
-          runEndToEndTests: ${{ and(ne(variables['Build.Reason'], 'Schedule'), eq('${{ parameters.runEndToEndTests }}', true)) }}
+          runEndToEndTests: ${{ and(ne(variables['Build.Reason'], 'Schedule'), parameters.runEndToEndTests) }}

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -12,6 +12,12 @@ trigger:
     include:
     - dev
 
+parameters:
+  - name: runEndToEndTests
+    type: boolean
+    default: true
+    displayName: "Run end-to-end tests"
+
 # CI only, does not trigger on PRs.
 pr: none
 
@@ -40,6 +46,14 @@ extends:
 
     stages:
     - stage: BuildAndTest
+      templateContext:
+        sdl:
+          codeql:
+            runSourceLanguagesInSourceAnalysis: true
+            buildIdentifier: java_additions_official
+            excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
       jobs:
       - template: /eng/ci/templates/official/jobs/build-and-test.yml@self
+        parameters:
+          runEndToEndTests: ${{ and(ne(variables['Build.Reason'], 'Schedule'), eq('${{ parameters.runEndToEndTests }}', true)) }}

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -40,6 +40,10 @@ extends:
       image: 1es-windows-2022
       os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Build
 

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -32,14 +32,14 @@ extends:
       image: 1es-windows-2022
       os: windows
 
-    sdl:
-      codeql:
-         compiled:
-           enabled: true
-         runSourceLanguagesInSourceAnalysis: true
-
     stages:
     - stage: Build
+      templateContext:
+        sdl:
+          codeql:
+            runSourceLanguagesInSourceAnalysis: true
+            buildIdentifier: java_library_public
+            excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
       jobs:
       - template: /eng/ci/templates/jobs/build.yml@self

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -24,6 +24,16 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
+variables:
+  - template: ci/variables/build.yml@eng
+  - template: ci/variables/cfs.yml@eng
+  - name: codeql.language
+    value: java,powershell
+  - name: codeql.buildIdentifier
+    value: java_library_public
+  - name: codeql.excludePathPatterns
+    value: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-worker'
+
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:
@@ -34,12 +44,6 @@ extends:
 
     stages:
     - stage: Build
-      templateContext:
-        sdl:
-          codeql:
-            runSourceLanguagesInSourceAnalysis: true
-            buildIdentifier: java_library_public
-            excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
       jobs:
       - template: /eng/ci/templates/jobs/build.yml@self

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -25,8 +25,6 @@ resources:
     ref: refs/tags/release
 
 variables:
-  - template: ci/variables/build.yml@eng
-  - template: ci/variables/cfs.yml@eng
   - name: codeql.language
     value: java,powershell
   - name: codeql.buildIdentifier

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -1,3 +1,9 @@
+parameters:
+  - name: runEndToEndTests
+    type: boolean
+    default: true
+    displayName: "Run end-to-end tests"
+
 jobs:
   - job: "Build_And_Test_Java_Library_Windows"
 
@@ -37,6 +43,7 @@ jobs:
         mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
         Copy-Item "confluent_cloud_cacert.pem" ".\target\azure-functions\azure-functions-java-endtoendtests"
       displayName: 'Package Java for E2E'
+      condition: eq('${{ parameters.runEndToEndTests }}', true)
 
     - task: DotNetCoreCLI@2
       retryCountOnTaskFailure: 3
@@ -66,4 +73,5 @@ jobs:
         ApplicationInsightAPPID: $(ApplicationInsightAPPID)
         ApplicationInsightAgentVersion: $(ApplicationInsightAgentVersion)
       displayName: 'Build & Run tests for java 8'
+      condition: eq('${{ parameters.runEndToEndTests }}', true)
     

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
       displayName: 'Install NuGet Tool'
 
     - pwsh: |
-        Write-Host "Java_HOME: $JAVA_HOME"
+        Write-Host "Java_HOME: $env:JAVA_HOME"
         Get-Command mvn
       displayName: 'Check Maven is installed'
 
@@ -39,39 +39,28 @@ jobs:
         $Env:Path = $Env:Path+";$currDir\Azure.Functions.Cli"
         ls $currDir\Azure.Functions.Cli
         func --version
-        cd ./azure-functions-java-worker/endtoendtests
+        cd ./azure-functions-java-worker/emulatedtests
         mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
-        Copy-Item "confluent_cloud_cacert.pem" ".\target\azure-functions\azure-functions-java-endtoendtests"
+        Copy-Item "confluent_cloud_cacert.pem" ".\target\azure-functions\azure-functions-java-emulatedtests"
       displayName: 'Package Java for E2E'
-      condition: eq('${{ parameters.runEndToEndTests }}', true)
+      condition: eq(${{ parameters.runEndToEndTests }}, true)
+
+    - bash: |
+        npm install -g azurite
+        mkdir azurite
+        azurite --silent --location azurite --debug azurite\debug.log &
+      displayName: 'Install and Run Azurite'
+      condition: eq(${{ parameters.runEndToEndTests }}, true)
 
     - task: DotNetCoreCLI@2
       retryCountOnTaskFailure: 3
       inputs:
         command: 'test'
         projects: |
-          azure-functions-java-worker\endtoendtests\Azure.Functions.Java.Tests.E2E\Azure.Functions.Java.Tests.E2E\Azure.Functions.Java.Tests.E2E.csproj
+          azure-functions-java-worker/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
       env:
-        AzureWebJobsStorage: $(AzureWebJobsStorage)
-        AzureWebJobsCosmosDBConnectionString: $(AzureWebJobsCosmosDBConnectionString)
-        AzureWebJobsSqlConnectionString: $(AzureWebJobsSqlConnectionString)
-        AzureWebJobsServiceBus: $(AzureWebJobsServiceBus)
-        AzureWebJobsEventHubReceiver: $(AzureWebJobsEventHubReceiver)
-        AzureWebJobsEventHubSender_2: $(AzureWebJobsEventHubSender_2)
-        AzureWebJobsEventHubSender: $(AzureWebJobsEventHubSender)
-        AzureWebJobsEventHubPath: $(AzureWebJobsEventHubPath)
-        SBTopicName: $(SBTopicName)
-        SBTopicSubName: $(SBTopicSubName)
-        CosmosDBDatabaseName: $(CosmosDBDatabaseName)
-        SBQueueName: $(SBQueueName)
-        BrokerList": $(BrokerList)
-        ConfluentCloudUsername: $(ConfluentCloudUsername)
-        ConfluentCloudPassword: $(ConfluentCloudPassword)
-        AzureWebJobsEventGridOutputBindingTopicUriString: $(AzureWebJobsEventGridOutputBindingTopicUriString)
-        AzureWebJobsEventGridOutputBindingTopicKeyString: $(AzureWebJobsEventGridOutputBindingTopicKeyString)
-        ApplicationInsightAPIKey: $(ApplicationInsightAPIKey)
-        ApplicationInsightAPPID: $(ApplicationInsightAPPID)
-        ApplicationInsightAgentVersion: $(ApplicationInsightAgentVersion)
+        AzureWebJobsStorage: "UseDevelopmentStorage=true"
+        JAVA_HOME: $(JAVA_HOME_8_X64)
       displayName: 'Build & Run tests for java 8'
-      condition: eq('${{ parameters.runEndToEndTests }}', true)
+      condition: eq(${{ parameters.runEndToEndTests }}, true)
     


### PR DESCRIPTION
- add exclude paths for codeql
- prevent end-to-end tests from running on scheduled codeql runs

changes have been tested