### PR TITLE
enable codeql on public pipeline

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -51,3 +51,4 @@ extends:
 
         jobs:
           - template: /eng/ci/templates/jobs/build.yml@self
+

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -30,7 +30,9 @@ variables:
   - name: codeql.buildIdentifier
     value: java_library_public
   - name: codeql.excludePathPatterns
-    value: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-worker'
+    value: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-worker'  
+  - name: codeql.compiled.enabled
+    value: true
 
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -1,28 +1,28 @@
 schedules:
-- cron: "0 0 * * *"
-  displayName: Nightly Build
-  branches:
-    include:
-      - dev
-  always: true
+  - cron: '0 0 * * *'
+    displayName: Nightly Build
+    branches:
+      include:
+        - dev
+    always: true
 
 trigger:
   batch: true
   branches:
     include:
-    - dev
+      - dev
 
 pr:
   branches:
     include:
-    - dev
+      - dev
 
 resources:
   repositories:
-  - repository: 1es
-    type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+    - repository: 1es
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
 
 variables:
   - name: codeql.language
@@ -30,7 +30,7 @@ variables:
   - name: codeql.buildIdentifier
     value: java_library_public
   - name: codeql.excludePathPatterns
-    value: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-worker'  
+    value: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-worker'
   - name: codeql.compiled.enabled
     value: true
 
@@ -47,7 +47,7 @@ extends:
       skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
 
     stages:
-    - stage: Build
+      - stage: Build
 
-      jobs:
-      - template: /eng/ci/templates/jobs/build.yml@self
+        jobs:
+          - template: /eng/ci/templates/jobs/build.yml@self


### PR DESCRIPTION
codeql.compiled.enabled true

by default it is not enabled for unofficial 1ES PT, we are using unofficial 1ES PT for public and official PT for internal