### PR TITLE
Change 'required' to 'isRequired' and remove the default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-library</artifactId>
-	<version>3.2.0</version>
+	<version>3.2.1</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpToolProperty.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpToolProperty.java
@@ -68,5 +68,5 @@ public @interface McpToolProperty {
      * 
      * @return true if required, false if optional
      */
-    boolean required() default false;
+    boolean isRequired();
 }


### PR DESCRIPTION
This pull request introduces a breaking change to the `McpToolProperty` annotation and updates the project version in `pom.xml`. The most significant change is the modification of the annotation's required property from an optional attribute to a mandatory method, which may impact all usages of this annotation.

**Breaking change to annotation API:**

* Changed the `McpToolProperty` annotation's `required()` attribute from an optional property with a default value to a mandatory method `isRequired()`, removing the default value and requiring explicit implementation.

**Build and versioning:**

* Updated the project version in `pom.xml` from `3.2.0` to `3.2.1`.