### PR TITLE
Add support for isRequired and adjust defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-library</artifactId>
-	<version>3.2.1</version>
+	<version>3.2.2</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpToolProperty.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpToolProperty.java
@@ -61,12 +61,19 @@ public @interface McpToolProperty {
      * 
      * @return Description of the property
      */
-    String description();
+    String description() default "";
 
     /**
      * Whether this property is required for tool execution.
      * 
      * @return true if required, false if optional
      */
-    boolean isRequired();
+    boolean isRequired() default false;
+
+    /**
+     * Whether this property is an array.
+     * 
+     * @return true if this property is an array, false otherwise
+     */
+    boolean isArray() default false;
 }

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpToolTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpToolTrigger.java
@@ -64,7 +64,7 @@ public @interface McpToolTrigger {
      * 
      * @return Description of the tool's functionality
      */
-    String description();
+    String description() default "";
 
     /**
      * JSON array defining expected tool properties.


### PR DESCRIPTION
This pull request introduces improvements to the annotation APIs for MCP tool integrations and updates the library version. The main changes are focused on making annotation attributes optional and adding new configuration options for tool properties.

Annotation API improvements:

* Made the `description` attribute optional (defaulting to an empty string) in both `McpToolProperty` and `McpToolTrigger` annotations, allowing users to omit descriptions if not needed. [[1]](diffhunk://#diff-e7aac61117dcbc990cd1aacf00ae0d43a2a0dab98518a5510498daef770cd4cfL64-R78) [[2]](diffhunk://#diff-5469dd64d31e3416288cba763d8ed5412620530d7fe44661acde2a967d782fd9L67-R67)
* Made the `isRequired` attribute optional (defaulting to `false`) in the `McpToolProperty` annotation, simplifying usage for optional properties.
* Added a new `isArray` attribute (defaulting to `false`) to the `McpToolProperty` annotation to specify if a property is an array, increasing flexibility in property definitions.

Dependency update:

* Updated the library version in `pom.xml` from `3.2.1` to `3.2.2`, indicating a new release with these enhancements.