### PR TITLE
Add McpResourceTrigger and McpMetadata annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-library</artifactId>
-	<version>3.2.3</version>
+	<version>3.2.4-beta</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-library</artifactId>
-	<version>3.2.4-beta</version>
+	<version>3.2.4</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpMetadata.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpMetadata.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.functions.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Attaches arbitrary JSON metadata to an MCP trigger (tool or resource).
+ * <p>
+ * This is a declarative annotation placed on the <b>same parameter</b> as the trigger
+ * annotation ({@link McpToolTrigger} or {@link McpResourceTrigger}). The metadata is surfaced
+ * in the MCP protocol's {@code _meta} field when clients call {@code tools/list} or
+ * {@code resources/list}.
+ * </p>
+ * <p>
+ * The {@code json} property must contain valid JSON. It can include any arbitrary key-value
+ * pairs such as author information, version numbers, UI hints, tags, or nested objects.
+ * </p>
+ *
+ * <p>Example with a resource trigger:</p>
+ * <pre>
+ * {@literal @}FunctionName("getReadme")
+ * public String getReadme(
+ *     {@literal @}McpResourceTrigger(
+ *         name = "context",
+ *         uri = "file://readme.md",
+ *         resourceName = "readme",
+ *         description = "Application readme file",
+ *         mimeType = "text/plain"
+ *     )
+ *     {@literal @}McpMetadata(
+ *         name = "context",
+ *         json = "{\"author\": \"John Doe\", \"version\": 1.0}"
+ *     ) String context,
+ *     final ExecutionContext executionContext
+ * ) {
+ *     return "# My Application";
+ * }
+ * </pre>
+ *
+ * <p>Example with a tool trigger:</p>
+ * <pre>
+ * {@literal @}FunctionName("getWeather")
+ * public String getWeather(
+ *     {@literal @}McpToolTrigger(
+ *         name = "context",
+ *         description = "Returns weather information"
+ *     )
+ *     {@literal @}McpMetadata(
+ *         name = "context",
+ *         json = "{\"version\": 1.0, \"author\": \"Jane Doe\"}"
+ *     ) String context
+ * ) {
+ *     return "Sunny, 72°F";
+ * }
+ * </pre>
+ *
+ * @see McpToolTrigger
+ * @see McpResourceTrigger
+ * @since 3.2.4
+ */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface McpMetadata {
+
+    /**
+     * The binding parameter name. Should match the {@code name()} of the trigger
+     * annotation on the same parameter.
+     *
+     * @return The parameter binding name
+     */
+    String name();
+
+    /**
+     * Defines how Functions runtime should treat the parameter value. Possible values are:
+     * <ul>
+     * <li>"": get the value as a string, and try to deserialize to actual parameter type like POJO</li>
+     * <li>string: always get the value as a string</li>
+     * <li>binary: get the value as a binary data, and try to deserialize to actual parameter type byte[]</li>
+     * </ul>
+     *
+     * @return The dataType which will be used by the Functions runtime.
+     */
+    String dataType() default "";
+
+    /**
+     * The metadata as a JSON string.
+     * <p>
+     * Must contain valid JSON. The contents are surfaced in the MCP protocol's
+     * {@code _meta} field when clients discover available tools or resources.
+     * </p>
+     *
+     * <p>Example:</p>
+     * <pre>
+     * json = "{\"author\": \"John Doe\", \"version\": 1.0, \"tags\": [\"utility\", \"time\"]}"
+     * </pre>
+     *
+     * @return The metadata JSON string
+     */
+    String json();
+}

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpResourceTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpResourceTrigger.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.functions.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Triggers an Azure Function when an MCP client requests to read a resource.
+ * <p>
+ * This annotation enables Azure Functions to expose content (files, data, images)
+ * as MCP resources that can be discovered and consumed by MCP-compatible clients
+ * like AI assistants. The function returns the resource content as a string (text)
+ * or byte[] (binary).
+ * </p>
+ *
+ * <p>Example (text resource):</p>
+ * <pre>
+ * {@literal @}FunctionName("getReadme")
+ * public String getReadme(
+ *     {@literal @}McpResourceTrigger(
+ *         name = "context",
+ *         uri = "file://readme.md",
+ *         resourceName = "readme",
+ *         description = "Application readme file",
+ *         mimeType = "text/plain"
+ *     ) String context,
+ *     final ExecutionContext executionContext
+ * ) {
+ *     return "# My Application\nThis is the readme content.";
+ * }
+ * </pre>
+ *
+ * @see McpToolTrigger
+ * @since 3.2.4
+ */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface McpResourceTrigger {
+
+    /**
+     * The binding name for the resource invocation context parameter.
+     *
+     * @return The parameter binding name
+     */
+    String name();
+
+    /**
+     * Defines how Functions runtime should treat the parameter value. Possible values are:
+     * <ul>
+     * <li>"": get the value as a string, and try to deserialize to actual parameter type like POJO</li>
+     * <li>string: always get the value as a string</li>
+     * <li>binary: get the value as a binary data, and try to deserialize to actual parameter type byte[]</li>
+     * </ul>
+     *
+     * @return The dataType which will be used by the Functions runtime.
+     */
+    String dataType() default "";
+
+    /**
+     * The URI of the MCP resource (e.g., "file://readme.md").
+     *
+     * @return The resource URI
+     */
+    String uri();
+
+    /**
+     * The display name of the MCP resource.
+     *
+     * @return The resource name
+     */
+    String resourceName();
+
+    /**
+     * The MIME type of the MCP resource (e.g., "text/plain", "image/png").
+     *
+     * @return The MIME type, or empty string if not specified
+     */
+    String mimeType() default "";
+
+    /**
+     * Human-readable description of this resource.
+     *
+     * @return Description of the resource
+     */
+    String description() default "";
+
+    /**
+     * The optional size of the resource in bytes. A value of -1 indicates
+     * that the size is not specified.
+     *
+     * @return The resource size in bytes, or -1 if not specified
+     */
+    long size() default -1;
+
+    /**
+     * JSON-serialized metadata for the MCP resource.
+     *
+     * @return JSON metadata string, or empty string if not specified
+     */
+    String metadata() default "";
+}

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpResourceTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpResourceTrigger.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
  *         name = "context",
  *         uri = "file://readme.md",
  *         resourceName = "readme",
+ *         title = "Application Readme",
  *         description = "Application readme file",
  *         mimeType = "text/plain"
  *     ) String context,
@@ -76,6 +77,17 @@ public @interface McpResourceTrigger {
      * @return The resource name
      */
     String resourceName();
+
+    /**
+     * Optional human-readable title for display purposes.
+     * <p>
+     * Unlike {@code resourceName} which is a programmatic identifier,
+     * this is a friendly label for UI presentation.
+     * </p>
+     *
+     * @return The display title, or empty string if not specified
+     */
+    String title() default "";
 
     /**
      * The MIME type of the MCP resource (e.g., "text/plain", "image/png").


### PR DESCRIPTION
## Summary

Adds two new annotations for MCP (Model Context Protocol) support:

### McpResourceTrigger
Trigger annotation for MCP resource functions. Applied to the parameter that receives the resource request data.

**Members:** `name()`, `dataType()`, `uri()`, `resourceName()`, `mimeType()`, `description()`, `size()`, `metadata()`

### McpMetadata
Companion annotation for attaching arbitrary JSON metadata to MCP triggers. Placed on the same parameter as the trigger annotation. The metadata is surfaced as the `_meta` field in the MCP protocol responses (`tools/list`, `resources/list`).

**Members:** `name()`, `dataType()`, `json()`

### Version
Library version bumped to **3.2.4**.

### Related PRs
- Maven plugin: https://github.com/microsoft/azure-maven-plugins/pull/2553
- Test app: https://github.com/Azure-Samples/remote-mcp-functions-java/pull/10