### PR TITLE
Add McpPromptTrigger and McpPromptArgument annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-library</artifactId>
-	<version>3.2.4</version>
+	<version>3.3.0</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpPromptArgument.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpPromptArgument.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.functions.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines a strongly-typed input argument for an MCP prompt function parameter.
+ * <p>
+ * Alternative to using JSON format in {@link McpPromptTrigger#promptArguments()}.
+ * Each annotated parameter receives a specific argument value from the prompt invocation.
+ * Unlike tool properties, prompt arguments are always strings — no type schema is needed.
+ * </p>
+ *
+ * <p>Example:</p>
+ * <pre>
+ * {@literal @}FunctionName("codeReview")
+ * public String codeReview(
+ *     {@literal @}McpPromptTrigger(name = "context", description = "Code review prompt") String context,
+ *     {@literal @}McpPromptArgument(
+ *         name = "code",
+ *         argumentName = "code",
+ *         description = "The code to review",
+ *         isRequired = true
+ *     ) String code,
+ *     {@literal @}McpPromptArgument(
+ *         name = "language",
+ *         argumentName = "language",
+ *         description = "The programming language"
+ *     ) String language
+ * ) {
+ *     return "Please review the following " + language + " code:\n\n" + code;
+ * }
+ * </pre>
+ *
+ * @see McpPromptTrigger
+ * @since 3.3.0
+ */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface McpPromptArgument {
+
+    /**
+     * The parameter binding name for the Azure Functions runtime.
+     *
+     * @return The parameter binding name
+     */
+    String name();
+
+    /**
+     * The name of the prompt argument as exposed in the MCP protocol.
+     *
+     * @return The argument name
+     */
+    String argumentName() default "";
+
+    /**
+     * Description of the argument's purpose and usage.
+     *
+     * @return Description of the argument
+     */
+    String description() default "";
+
+    /**
+     * Whether this argument is required for prompt invocation.
+     *
+     * @return true if required, false if optional
+     */
+    boolean isRequired() default false;
+}

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpPromptArgument.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpPromptArgument.java
@@ -18,21 +18,25 @@ import java.lang.annotation.Target;
  * Each annotated parameter receives a specific argument value from the prompt invocation.
  * Unlike tool properties, prompt arguments are always strings — no type schema is needed.
  * </p>
+ * <p>
+ * The {@code name()} value serves as both the binding parameter name and the argument name
+ * exposed in the MCP protocol (the Maven plugin patches it into {@code argumentName} in
+ * function.json). This follows the same convention as {@link McpToolProperty} where
+ * {@code name()} is patched into {@code propertyName}.
+ * </p>
  *
  * <p>Example:</p>
  * <pre>
  * {@literal @}FunctionName("codeReview")
  * public String codeReview(
- *     {@literal @}McpPromptTrigger(name = "context", description = "Code review prompt") String context,
+ *     {@literal @}McpPromptTrigger(name = "code_review", description = "Code review prompt") String context,
  *     {@literal @}McpPromptArgument(
  *         name = "code",
- *         argumentName = "code",
  *         description = "The code to review",
  *         isRequired = true
  *     ) String code,
  *     {@literal @}McpPromptArgument(
  *         name = "language",
- *         argumentName = "language",
  *         description = "The programming language"
  *     ) String language
  * ) {
@@ -48,18 +52,13 @@ import java.lang.annotation.Target;
 public @interface McpPromptArgument {
 
     /**
-     * The parameter binding name for the Azure Functions runtime.
-     *
-     * @return The parameter binding name
-     */
-    String name();
-
-    /**
-     * The name of the prompt argument as exposed in the MCP protocol.
+     * The argument name used as both the binding parameter name and the MCP protocol
+     * argument identifier. The Maven plugin patches this into {@code argumentName}
+     * in function.json.
      *
      * @return The argument name
      */
-    String argumentName() default "";
+    String name();
 
     /**
      * Description of the argument's purpose and usage.

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpPromptTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpPromptTrigger.java
@@ -20,36 +20,25 @@ import java.lang.annotation.Target;
  * JSON-serialized {@code GetPromptResult} for multi-message or rich content responses.
  * </p>
  *
- * <p>Example with inline arguments:</p>
+ * <p>Example:</p>
  * <pre>
  * {@literal @}FunctionName("codeReview")
  * public String codeReview(
  *     {@literal @}McpPromptTrigger(
  *         name = "code_review",
- *         description = "Generates a code review prompt",
- *         promptArguments = "[{\"name\":\"code\",\"description\":\"The code to review\",\"required\":true}," +
- *                           "{\"name\":\"language\",\"description\":\"Programming language\",\"required\":false}]"
- *     ) String context
- * ) {
- *     return "Please review the following code...";
- * }
- * </pre>
- *
- * <p>Example with {@link McpPromptArgument} annotations:</p>
- * <pre>
- * {@literal @}FunctionName("summarize")
- * public String summarize(
- *     {@literal @}McpPromptTrigger(
- *         name = "summarize",
- *         description = "Summarizes the provided text"
+ *         description = "Generates a code review prompt"
  *     ) String context,
  *     {@literal @}McpPromptArgument(
- *         name = "text",
- *         description = "The text to summarize",
+ *         name = "code",
+ *         description = "The code to review",
  *         isRequired = true
- *     ) String text
+ *     ) String code,
+ *     {@literal @}McpPromptArgument(
+ *         name = "language",
+ *         description = "The programming language"
+ *     ) String language
  * ) {
- *     return "Please provide a concise summary of: " + text;
+ *     return "Please review the following " + language + " code:\n\n" + code;
  * }
  * </pre>
  *

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpPromptTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpPromptTrigger.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.functions.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Triggers an Azure Function when invoked by the Model Context Protocol (MCP) prompt system.
+ * <p>
+ * This annotation enables Azure Functions to expose prompt templates that MCP-compatible clients
+ * can discover via {@code prompts/list} and invoke via {@code prompts/get} with arguments.
+ * The function returns a plain string (auto-wrapped into a single user message) or a
+ * JSON-serialized {@code GetPromptResult} for multi-message or rich content responses.
+ * </p>
+ *
+ * <p>Example with inline arguments:</p>
+ * <pre>
+ * {@literal @}FunctionName("codeReview")
+ * public String codeReview(
+ *     {@literal @}McpPromptTrigger(
+ *         name = "code_review",
+ *         description = "Generates a code review prompt",
+ *         promptArguments = "[{\"name\":\"code\",\"description\":\"The code to review\",\"required\":true}," +
+ *                           "{\"name\":\"language\",\"description\":\"Programming language\",\"required\":false}]"
+ *     ) String context
+ * ) {
+ *     return "Please review the following code...";
+ * }
+ * </pre>
+ *
+ * <p>Example with {@link McpPromptArgument} annotations:</p>
+ * <pre>
+ * {@literal @}FunctionName("summarize")
+ * public String summarize(
+ *     {@literal @}McpPromptTrigger(
+ *         name = "summarize",
+ *         description = "Summarizes the provided text"
+ *     ) String context,
+ *     {@literal @}McpPromptArgument(
+ *         name = "text",
+ *         argumentName = "text",
+ *         description = "The text to summarize",
+ *         isRequired = true
+ *     ) String text
+ * ) {
+ *     return "Please provide a concise summary of: " + text;
+ * }
+ * </pre>
+ *
+ * @see McpPromptArgument
+ * @see McpMetadata
+ * @since 3.3.0
+ */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface McpPromptTrigger {
+
+    /**
+     * The variable name used in function.json and also the unique prompt name
+     * that MCP clients use to identify and invoke this prompt.
+     * <p>
+     * This serves as both the binding parameter name and the prompt identifier.
+     * It must be unique across all prompts in the function app.
+     * </p>
+     *
+     * @return The prompt name / parameter binding name
+     */
+    String name();
+
+    /**
+     * Defines how Functions runtime should treat the parameter value. Possible values are:
+     * <ul>
+     * <li>"": get the value as a string, and try to deserialize to actual parameter type like POJO</li>
+     * <li>string: always get the value as a string</li>
+     * <li>binary: get the value as a binary data, and try to deserialize to actual parameter type byte[]</li>
+     * </ul>
+     *
+     * @return The dataType which will be used by the Functions runtime.
+     */
+    String dataType() default "";
+
+    /**
+     * Human-readable description of what this prompt does.
+     *
+     * @return Description of the prompt's purpose
+     */
+    String description() default "";
+
+    /**
+     * Optional human-readable title for display purposes.
+     *
+     * @return The display title, or empty string if not specified
+     */
+    String title() default "";
+
+    /**
+     * JSON array defining expected prompt arguments.
+     * <p>
+     * Each argument should be a JSON object with: name, description, required.
+     * Alternative: use {@link McpPromptArgument} annotations on parameters.
+     * </p>
+     *
+     * <p>Example:</p>
+     * <pre>
+     * [{"name":"code","description":"The code to review","required":true}]
+     * </pre>
+     *
+     * @return JSON array of argument definitions, or empty string
+     */
+    String promptArguments() default "";
+
+    /**
+     * JSON-serialized metadata for the MCP prompt.
+     *
+     * @return JSON metadata string, or empty string if not specified
+     */
+    String metadata() default "";
+
+    /**
+     * JSON array of icons for the MCP prompt.
+     *
+     * @return JSON array of icon definitions, or empty string if not specified
+     */
+    String icons() default "";
+}

--- a/src/main/java/com/microsoft/azure/functions/annotation/McpPromptTrigger.java
+++ b/src/main/java/com/microsoft/azure/functions/annotation/McpPromptTrigger.java
@@ -45,7 +45,6 @@ import java.lang.annotation.Target;
  *     ) String context,
  *     {@literal @}McpPromptArgument(
  *         name = "text",
- *         argumentName = "text",
  *         description = "The text to summarize",
  *         isRequired = true
  *     ) String text


### PR DESCRIPTION
## Summary

Adds annotation definitions for MCP prompt support ([issue #861](https://github.com/Azure/azure-functions-java-worker/issues/861)).

## New annotations

### McpPromptTrigger

Trigger annotation for MCP prompt functions. Properties:

- `name()` — binding parameter name and unique prompt identifier (same convention as McpToolTrigger)
- `description()` — human-readable description
- `title()` — optional display title
- `promptArguments()` — inline JSON array of argument definitions (alternative to McpPromptArgument annotations)
- `metadata()` — optional JSON metadata
- `icons()` — optional JSON icons array
- `dataType()` — serialization hint

### McpPromptArgument

Input binding annotation for individual prompt arguments. Properties:

- `name()` — binding parameter name
- `argumentName()` — argument name exposed in MCP protocol
- `description()` — argument description
- `isRequired()` — whether the argument is required

## Usage

```java
@FunctionName("CodeReviewPrompt")
public String codeReview(
    @McpPromptTrigger(name = "code_review", description = "Code review prompt", title = "Code Review")
    String context,
    @McpPromptArgument(name = "code", argumentName = "code", description = "The code to review", isRequired = true)
    String code,
    @McpPromptArgument(name = "language", argumentName = "language", description = "The programming language")
    String language
) {
    return "Please review the following " + language + " code:\n\n" + code;
}
```

## Related PRs

- [microsoft/azure-maven-plugins#2554](https://github.com/microsoft/azure-maven-plugins/pull/2554) — Maven plugin: registers bindings, generates function.json
- [Azure-Samples/remote-mcp-functions-java#17](https://github.com/Azure-Samples/remote-mcp-functions-java/pull/17) — Sample prompt functions
