### PR TITLE
Route npm and NuGet restores through CFS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure-rest:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@colors:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@dabh:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-joda:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@microsoft:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@so-ric:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public"
+         value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/build.ps1
+++ b/build.ps1
@@ -68,6 +68,13 @@ $FUNC_RUNTIME_VERSION = 'latest'
 Write-Host "Installing Core Tools globlally using npm, version: $FUNC_RUNTIME_VERSION ..."
 
 $FUNC_CLI_DIRECTORY = Join-Path $currDir 'Azure.Functions.Cli'
+$repoNpmConfig = Join-Path $PSScriptRoot '.npmrc'
+if ([string]::IsNullOrWhiteSpace($Env:NPM_CONFIG_USERCONFIG)) {
+  $Env:NPM_CONFIG_USERCONFIG = $repoNpmConfig
+}
+if (-not (Test-Path -LiteralPath $Env:NPM_CONFIG_USERCONFIG -PathType Leaf)) {
+  throw "NPM_CONFIG_USERCONFIG does not point to a file: $Env:NPM_CONFIG_USERCONFIG"
+}
 
 # 1. Clean previous install
 Remove-Item -Recurse -Force $FUNC_CLI_DIRECTORY -ErrorAction Ignore
@@ -78,7 +85,18 @@ $globalNode   = (npm root   -g | Out-String).Trim()         # e.g. /usr/local/li
 $moduleRoot   = Join-Path $globalNode 'azure-functions-core-tools'
 
 # 3. npm install → temp folder
-npm install -g azure-functions-core-tools@$FUNC_RUNTIME_VERSION --unsafe-perm true --foreground-scripts --loglevel verbose
+$npmInstallArguments = @(
+  'install'
+  '--global'
+  "azure-functions-core-tools@$FUNC_RUNTIME_VERSION"
+  '--unsafe-perm'
+  'true'
+  '--foreground-scripts'
+  '--loglevel'
+  'verbose'
+)
+& npm @npmInstallArguments
+StopOnFailedExecution
 
 # 4. Copy CLI payload into the layout required tests
 Copy-Item "$moduleRoot\bin\*" $FUNC_CLI_DIRECTORY -Recurse -Force

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -8,9 +8,17 @@ jobs:
       os: windows
 
     steps:
+    - task: npmAuthenticate@0
+      displayName: 'Authenticate npm to CFS'
+      inputs:
+        workingFile: .npmrc
+
     - pwsh: |
         Write-Host "Java_HOME: $JAVA_HOME"
         Get-Command mvn
       displayName: 'Check Maven is installed'
+
     - pwsh: '& .\build.ps1'
       displayName: 'Build project with java library'
+      env:
+        NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -16,10 +16,13 @@ jobs:
       ApplicationInsightAgentVersion: 3.5.2
 
     steps:
-    - task: NuGetToolInstaller@1
+    - task: npmAuthenticate@0
+      displayName: 'Authenticate npm to CFS'
       inputs:
-        checkLatest: true
-      displayName: 'Install NuGet Tool'
+        workingFile: .npmrc
+
+    - task: NuGetAuthenticate@1
+      displayName: 'Authenticate NuGet to CFS'
 
     - pwsh: |
         Write-Host "Java_HOME: $env:JAVA_HOME"
@@ -30,9 +33,11 @@ jobs:
       displayName: 'Install .NET 6'
       inputs:
         version: 6.0.x
-        
+
     - pwsh: '& .\build.ps1'
       displayName: 'Build project with java library'
+      env:
+        NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
     - pwsh: |
         $currDir =  Get-Location
@@ -45,12 +50,25 @@ jobs:
       displayName: 'Package Java for E2E'
       condition: eq(${{ parameters.runEndToEndTests }}, true)
 
+    - task: DotNetCoreCLI@2
+      retryCountOnTaskFailure: 3
+      inputs:
+        command: 'restore'
+        projects: |
+          azure-functions-java-worker/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
+        feedsToUse: 'config'
+        nugetConfigPath: 'NuGet.config'
+      displayName: 'Restore E2E tests from CFS'
+      condition: eq(${{ parameters.runEndToEndTests }}, true)
+
     - bash: |
         npm install -g azurite
         mkdir azurite
         azurite --silent --location azurite --debug azurite\debug.log &
       displayName: 'Install and Run Azurite'
       condition: eq(${{ parameters.runEndToEndTests }}, true)
+      env:
+        NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
     - task: DotNetCoreCLI@2
       retryCountOnTaskFailure: 3
@@ -58,6 +76,7 @@ jobs:
         command: 'test'
         projects: |
           azure-functions-java-worker/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
+        arguments: '--no-restore'
       env:
         AzureWebJobsStorage: "UseDevelopmentStorage=true"
         JAVA_HOME: $(JAVA_HOME_8_X64)


### PR DESCRIPTION
## Summary

- route the repository's global `azure-functions-core-tools` and Azurite npm installs through `azfunc/public/upstream-public`
- authenticate npm independently in the public and official Azure Pipelines jobs and pass `NPM_CONFIG_USERCONFIG` explicitly to every global install context
- add a clear-first, wildcard-mapped root `NuGet.config`, authenticate the official job, explicitly restore the detached Java worker E2E project from that config, and prevent the later test command from restoring implicitly
- remove the unused `NuGetToolInstaller@1` download from the official job

## Audit

All 63 tracked repository paths were audited across CI, build, release, development, package, Docker, detached-project, tool, and helper entry points.

- In scope: the two global npm installs and the detached `.NET` E2E project cloned by `build.ps1`
- Out of scope: the repository's Maven-only Java graph
- Not present: repository-owned `package.json`, Python/pip/uv surfaces, Dockerfiles, or customer templates/scaffolding that require changes
- No package lockfiles were rewritten, and no fallback registry, `always-auth`, or committed credential was added

## Validation

- Installed `azure-functions-core-tools@latest` (`4.12.1`) and `azurite@latest` (`3.36.0`) from separate empty npm caches and isolated global prefixes under `C:\cfs space\...`
- Resolved the combined 341-package production graph, including every current production scope, exclusively through Azure Artifacts/CFS package hosts; no request used `registry.npmjs.org`
- Restored the detached Java worker E2E project at worker commit `f6ad2a2c6bd7a537bc2b2d5afa7951ca700b2528` from an empty NuGet cache under `C:\cfs space\...`: 126 libraries, no `nuget.org` request
- Built that project with .NET SDK `6.0.428` using `--no-restore` with 0 warnings and 0 errors, then discovered 8 tests using `--no-restore --no-build`
- Ran `mvnBuild.bat` with JDK 8 and an isolated empty Maven repository: build succeeded; 2 tests passed
- Audited all three generated JARs and the detached .NET build output: no feed configs, credentials, package lockfiles, or `node_modules`

The first Maven attempt encountered an empty POM in the pre-existing user cache; the unchanged build passed from an isolated repository, confirming that was local cache corruption rather than a branch regression.
